### PR TITLE
NDS-000 Breadcrumb type hotfix

### DIFF
--- a/components/nds-breadcrumbs/README.md
+++ b/components/nds-breadcrumbs/README.md
@@ -76,9 +76,9 @@ A custom tag type. Defaults to a normal HTMLAnchorElement. Use this prop to use 
 
 ###### children
 
-- Type: `string`
+- Type: `React.ReactNode`
 
-The text of the breadcrumb
+The text of the breadcrumb. Can accept any valid React node, but should be limited to a string to conform with the design system.
 
 ### SCSS
 

--- a/components/nds-breadcrumbs/nds-breadcrumbs.d.ts
+++ b/components/nds-breadcrumbs/nds-breadcrumbs.d.ts
@@ -2,7 +2,7 @@ declare module "@nice-digital/nds-breadcrumbs" {
 	import React = require("react");
 
 	export interface BreadcrumbProps {
-		children: string;
+		children: React.ReactNode;
 		to?: string;
 		elementType?: React.ElementType;
 	}


### PR DESCRIPTION
`Breadcrumb` required a children type of ReactNode to accept ternaries and conditionals as children.